### PR TITLE
Upgrade to node 20.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,5 +12,5 @@ inputs:
     description: The repository with the package.
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Node 16 is deprecated: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/